### PR TITLE
Adding a setup.py file.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 *.pyc
 .idea
+
+*.egg-info/

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,16 @@
+from pip.req import parse_requirements
+from setuptools import setup
+import uuid
+
+setup(
+        name='json2csv',
+        version='0.1',
+        modules=['json2csv'],
+        scripts=['json2csv.py'],
+        url='https://github.com/evidens/json2csv',
+        license='MIT License',
+        author='evidens',
+        author_email='',
+        description='Converts JSON files to CSV (pulling data from nested structures). Useful for Mongo data',
+        install_requires= [str(ir.req) for ir in parse_requirements('requirements.txt', session=uuid.uuid1())]
+)


### PR DESCRIPTION
This is necessary in order to add json2csv as a project
dependency. If this is merged, it becomes as simple as
adding:

    git+https://github.com/evidens/json2csv

to a `requirements.txt` file.