### PR TITLE
Add custom csv delimiter option

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ For MongoDB (multiple JSON objects per file, which is non-standard JSON):
 
     python json2csv.py --each-line /path/to/json_file.json /path/to/outline_file.json
 
+For custom CSV delimiter output:
+
+    python json2csv.py /path/to/json_file.json /path/to/outline_file.json --csv-delimiter ';'
+
 ## Outline Format
 
 For this JSON file:

--- a/json2csv.py
+++ b/json2csv.py
@@ -90,7 +90,7 @@ class Json2Csv(object):
         else:
             return unicode(item)
 
-    def write_csv(self, filename='output.csv', make_strings=False):
+    def write_csv(self, filename='output.csv', make_strings=False, delimiter=','):
         """Write the processed rows to the given filename
         """
         if (len(self.rows) <= 0):
@@ -100,7 +100,7 @@ class Json2Csv(object):
         else:
             out = self.rows
         with open(filename, 'wb+') as f:
-            writer = csv.DictWriter(f, self.key_map.keys())
+            writer = csv.DictWriter(f, self.key_map.keys(), delimiter=delimiter)
             writer.writeheader()
             writer.writerows(out)
 
@@ -131,6 +131,8 @@ def init_parser():
                         help="Path to csv file to output")
     parser.add_argument(
         '--strings', help="Convert lists, sets, and dictionaries fully to comma-separated strings.", action="store_true", default=True)
+    parser.add_argument('--csv-delimiter', type=str, default=',',
+                        help="Delimiter for csv output")
 
     return parser
 
@@ -152,4 +154,4 @@ if __name__ == '__main__':
         fileName, fileExtension = os.path.splitext(args.json_file.name)
         outfile = fileName + '.csv'
 
-    loader.write_csv(filename=outfile, make_strings=args.strings)
+    loader.write_csv(filename=outfile, make_strings=args.strings, delimiter=args.csv_delimiter)

--- a/tests.py
+++ b/tests.py
@@ -2,7 +2,7 @@ import unittest
 import json
 from json2csv import Json2Csv, MultiLineJson2Csv
 from gen_outline import make_outline
-
+import os
 
 class TestJson2Csv(unittest.TestCase):
 
@@ -115,6 +115,41 @@ class TestJson2Csv(unittest.TestCase):
     def test_write_csv(self):
         pass
 
+    def test_custom_delimiter(self):
+        outline = {"map": [['author', 'source.author'], ['message', 'message.original']], "collection": "nodes"}
+        loader = Json2Csv(outline)
+        with open('fixtures/data.json') as f:
+            loader.load(f)
+
+        filename = "test.csv"
+        loader.write_csv(filename=filename, delimiter=';')
+        output = open(filename, "r")
+        csvString = output.read()
+
+        author = 'author'
+        delimiterSubstring = csvString[len(author):len(author)+1]
+
+        self.assertEqual(delimiterSubstring, ';')
+
+        os.remove(filename)
+
+    def test_default_delimiter(self):
+        outline = {"map": [['author', 'source.author'], ['message', 'message.original']], "collection": "nodes"}
+        loader = Json2Csv(outline)
+        with open('fixtures/data.json') as f:
+            loader.load(f)
+
+        filename = "test.csv"
+        loader.write_csv(filename=filename)
+        output = open(filename, "r")
+        csvString = output.read()
+
+        author = 'author'
+        delimiterSubstring = csvString[len(author):len(author)+1]
+
+        self.assertEqual(delimiterSubstring, ',')
+
+        os.remove(filename)
 
 class TestMultiLineJson2Csv(unittest.TestCase):
 


### PR DESCRIPTION
Hi there, you'll have to forgive me for this is my very first Python PR. I may be completely unawares of how you can pull this off in another way. If anything whatsoever needs changing, know you're talking to a Python n00b, but a professional programmer.

Anyway, I was finding myself in need of this functionality as I had fields with `,` in them, pesky formatted currencies for example.

I'm by no means a 🐍 Wizard and I enjoyed stumbling upon this project to learn how to do basic things. Including Unit Tests and a bunch of other concepts I would use in Swift/Obj-C/JavaScript. The project is well laid out and with reasonably sized clean functions, and tests!

I did consider refactoring how the CSV writing occurred, so that the Unit Tests didn't have to rely on an outputted file, nor having to cleanup afterwards. But wanted to see if this would pass.